### PR TITLE
fix Gradle 4.3 deprecation warnings

### DIFF
--- a/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
@@ -107,7 +107,6 @@ class MacAppBundlePlugin implements Plugin<Project> {
         task.inputs.property("MacAppBundlePlugin runtimeConfigurationName", {project.macAppBundle.runtimeConfigurationName})
         task.inputs.property("MacAppBundlePlugin icon", {project.macAppBundle.icon})
         task.inputs.property("MacAppBundlePlugin jvmVersion", {project.macAppBundle.jvmVersion})
-        task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage})
         task.inputs.property("MacAppBundlePlugin appName", {project.macAppBundle.appName})
         task.inputs.property("MacAppBundlePlugin volumeName", {project.macAppBundle.volumeName})
         task.inputs.property("MacAppBundlePlugin dmgName", {project.macAppBundle.dmgName})
@@ -123,10 +122,8 @@ class MacAppBundlePlugin implements Plugin<Project> {
         task.inputs.property("MacAppBundlePlugin bundleDevelopmentRegion", {project.macAppBundle.bundleDevelopmentRegion})
         task.inputs.property("MacAppBundlePlugin bundleJRE", {project.macAppBundle.bundleJRE})
         task.inputs.property("MacAppBundlePlugin jreHome", {project.macAppBundle.jreHome})
-        task.inputs.property("MacAppBundlePlugin certIdentity", {project.macAppBundle.certIdentity})
         task.inputs.property("MacAppBundlePlugin codeSignCmd", {project.macAppBundle.codeSignCmd})
         task.inputs.property("MacAppBundlePlugin codeSignDeep", {project.macAppBundle.codeSignDeep})
-        task.inputs.property("MacAppBundlePlugin keyChain", {project.macAppBundle.keyChain})
         task.inputs.property("MacAppBundlePlugin backgroundScript", {project.macAppBundle.backgroundScript})
         task.inputs.property("MacAppBundlePlugin appIconX", {project.macAppBundle.appIconX})
         task.inputs.property("MacAppBundlePlugin appIconY", {project.macAppBundle.appIconY})
@@ -134,6 +131,14 @@ class MacAppBundlePlugin implements Plugin<Project> {
         task.inputs.property("MacAppBundlePlugin appFolderY", {project.macAppBundle.appFolderY})
         task.inputs.property("MacAppBundlePlugin backgroundImageWidth", {project.macAppBundle.backgroundImageWidth})
         task.inputs.property("MacAppBundlePlugin backgroundImageHeight", {project.macAppBundle.backgroundImageHeight})
+
+        // optional inputs
+        //     code below should be changed to task.inputs.property("...", {...}).optional()
+        //     once minimal supported Gradle version is 4.3
+        if(project.macAppBundle.backgroundImage) task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage})
+        if(project.macAppBundle.certIdentity) task.inputs.property("MacAppBundlePlugin certIdentity", {project.macAppBundle.certIdentity})
+        if(project.macAppBundle.keyChain) task.inputs.property("MacAppBundlePlugin keyChain", {project.macAppBundle.keyChain})
+        
         return task
     }
 

--- a/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
@@ -133,7 +133,8 @@ class MacAppBundlePlugin implements Plugin<Project> {
         task.inputs.property("MacAppBundlePlugin backgroundImageHeight", {project.macAppBundle.backgroundImageHeight})
 
         // optional inputs
-        //     code below should be changed to task.inputs.property("...", {...}).optional()
+        //     code below should be changed to 
+        //     task.inputs.property("...", {...}).optional(true)
         //     once minimal supported Gradle version is 4.3
         if(project.macAppBundle.backgroundImage) task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage})
         if(project.macAppBundle.certIdentity) task.inputs.property("MacAppBundlePlugin certIdentity", {project.macAppBundle.certIdentity})


### PR DESCRIPTION
Gradle 4.3 causes warnings like this:
```
> Task :foo:generatePlist
Some problems were found with the configuration of task ':foo:generatePlist'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated and is scheduled to be removed in Gradle 5.0.
 - No value has been specified for property 'MacAppBundlePlugin certIdentity'.
 - No value has been specified for property 'MacAppBundlePlugin keyChain'.
 - No value has been specified for property 'MacAppBundlePlugin backgroundImage'.
```

My PR changes unconditional
```groovy
task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage})
```
to
```groovy
if(project.macAppBundle.backgroundImage) task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage})
```

The code should actually look like this:
```groovy
task.inputs.property("MacAppBundlePlugin backgroundImage", {project.macAppBundle.backgroundImage}).optional(true)
```
But that code would only work with Gradle 4.3 or later while my current solution also works with previous versions.

See the discussion over at [Gradle 4.3-rc-2 is now available for testing](https://discuss.gradle.org/t/gradle-4-3-rc-2-is-now-available-for-testing/24456/5?u=huxi).

Caveat: I don't know if I handled all values that are actually optional. Those are the three values that triggered the warning in my build. Others might be needed in addition to the ones I handled.