### PR TITLE
Fixes for DMG creation

### DIFF
--- a/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
@@ -280,15 +280,6 @@ class MacAppBundlePlugin implements Plugin<Project> {
                 task.from "${->project.macAppBundle.backgroundImage}"
                 task.into "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/.background"
             }
-            task.doLast {
-                String backgroundImage = new File(project.macAppBundle.backgroundImage).getName() // just name, not paths    
-                def imageWidth = runCmd(["sips", "-g", "pixelWidth", "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/.background/${backgroundImage}"], "Unable to determine image size with sips")
-                imageWidth = imageWidth.tokenize().last();
-                def imageHeight = runCmd(["sips", "-g", "pixelHeight", "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/.background/${backgroundImage}"], "Unable to determine image size with sips")
-                imageHeight = imageHeight.tokenize().last();
-                project.macAppBundle.backgroundImageWidth = imageWidth
-                project.macAppBundle.backgroundImageHeight = imageHeight
-            }
         }
         return task
     }
@@ -341,6 +332,14 @@ class MacAppBundlePlugin implements Plugin<Project> {
             task.doLast {
                 if (project.macAppBundle.backgroundImage != null) {
                     String backgroundImage = new File(project.macAppBundle.backgroundImage).getName() // just name, not paths
+
+                    def imageWidth = runCmd(["sips", "-g", "pixelWidth", "${-> project.buildDir}/${-> project.macAppBundle.appOutputDir}/.background/${backgroundImage}"], "Unable to determine image size with sips")
+                    imageWidth = imageWidth.tokenize().last()
+                    def imageHeight = runCmd(["sips", "-g", "pixelHeight", "${-> project.buildDir}/${-> project.macAppBundle.appOutputDir}/.background/${backgroundImage}"], "Unable to determine image size with sips")
+                    imageHeight = imageHeight.tokenize().last()
+                    project.macAppBundle.backgroundImageWidth = imageWidth
+                    project.macAppBundle.backgroundImageHeight = imageHeight
+
                     doBackgroundImageAppleScript(dmgOutDir,
                                                  tmpDmgName,
                                                   "${->project.macAppBundle.dmgName}.dmg",

--- a/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/MacAppBundlePlugin.groovy
@@ -415,7 +415,8 @@ class MacAppBundlePlugin implements Plugin<Project> {
         def engine = new SimpleTemplateEngine()
         def template = engine.createTemplate(backgroundScript).make(binding)
 
-//        sleep 2000
+        // This delay removes error "Finder got an error: Can’t get disk (-1728)"
+        sleep 2000
         def appleScriptCmd = "osascript".execute()
         appleScriptCmd.withWriter { writer ->
             writer << template.toString()


### PR DESCRIPTION
Fixed issue "Finder got an error: Can't get disk (1728)" by adding a delay of 2 seconds (it was commented)
Fixed issue when DMG windows size was set to default (100,100) instead of background image size due to Gradle cache of copyBackgroundImage task.