### PR TITLE
Fix property key value types

### DIFF
--- a/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
@@ -64,7 +64,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
                 key('CFBundleShortVersionString')
                 string(project.version)
                 key('CFBundleAllowMixedLocalizations')
-                if (extension.bundleAllowMixedLocalizations) { string('true') } else { string('false') }
+                if (extension.bundleAllowMixedLocalizations) { xml.true() } else { xml.false() }
                 key('NSHighResolutionCapable')
                 if (extension.highResolutionCapable) { string('true') } else { string('false') }
                 key('CFBundleSignature')
@@ -139,7 +139,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
                 key('CFBundleVersion')
                 string(project.version)
                 key('CFBundleAllowMixedLocalizations')
-                if (extension.bundleAllowMixedLocalizations) { string('true') } else { string('false') }
+                if (extension.bundleAllowMixedLocalizations) { xml.true() } else { xml.false() }
                 key('NSHighResolutionCapable')
                 if (extension.highResolutionCapable) { string('true') } else { string('false') }
                 key('CFBundleExecutable')

--- a/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
@@ -31,7 +31,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
             writeInfoPlistAppleJava();
         }
     }
-    
+
     def void writeInfoPlistOracleJava() {
         MacAppBundlePluginExtension extension = project.macAppBundle
         def file = getPlistFile()
@@ -51,14 +51,14 @@ class GenerateInfoPlistTask  extends DefaultTask {
                 string(project.file(extension.icon).name)
                 key('CFBundleIdentifier')
                 string(extension.bundleIdentifier)
-                
+
                 key('CFBundleInfoDictionaryVersion')
                 string(extension.bundleInfoDictionaryVersion)
                 key('CFBundleName')
                 string(extension.appName)
                 key('CFBundlePackageType')
                 string(extension.bundlePackageType)
-                
+
                 key('CFBundleVersion')
                 string(project.version)
                 key('CFBundleShortVersionString')
@@ -112,7 +112,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
         }
         writer.close()
     }
-    
+
     def void writeInfoPlistAppleJava() {
         MacAppBundlePluginExtension extension = project.macAppBundle
         def classpath;
@@ -189,7 +189,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
         } else if (value instanceof Date)  {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
             xml.date(sdf.format(value));
-            //YYYY-MM-DD HH:MM:SS 
+            //YYYY-MM-DD HH:MM:SS
         } else if (value instanceof Short || value instanceof Integer)  {
             xml.integer(value)
         } else if (value instanceof Float || value instanceof Double)  {

--- a/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
+++ b/src/main/groovy/edu/sc/seis/macAppBundle/GenerateInfoPlistTask.groovy
@@ -66,7 +66,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
                 key('CFBundleAllowMixedLocalizations')
                 if (extension.bundleAllowMixedLocalizations) { xml.true() } else { xml.false() }
                 key('NSHighResolutionCapable')
-                if (extension.highResolutionCapable) { string('true') } else { string('false') }
+                if (extension.highResolutionCapable) { xml.true() } else { xml.false() }
                 key('CFBundleSignature')
                 string(extension.creatorCode)
                 if (extension.bundleJRE) {
@@ -141,7 +141,7 @@ class GenerateInfoPlistTask  extends DefaultTask {
                 key('CFBundleAllowMixedLocalizations')
                 if (extension.bundleAllowMixedLocalizations) { xml.true() } else { xml.false() }
                 key('NSHighResolutionCapable')
-                if (extension.highResolutionCapable) { string('true') } else { string('false') }
+                if (extension.highResolutionCapable) { xml.true() } else { xml.false() }
                 key('CFBundleExecutable')
                 string(extension.bundleExecutable)
                 key('CFBundleDevelopmentRegion')


### PR DESCRIPTION
I noticed that the gradle-macappbundle plug-in uses the wrong value type (`String` instead of `Boolean`) for property keys `CFBundleAllowMixedLocalizations` and `NSHighResolutionCapable` -- at least according to the Apple Developer Documentation.